### PR TITLE
fix issue with back-slash on Mac numpad keyboard

### DIFF
--- a/jwerty.js
+++ b/jwerty.js
@@ -191,7 +191,8 @@
             period: 190,
             'full-stop': 190,
             // Slash, or /, or forward-slash
-            '/': 191,
+            // '/': 191,
+            '/': 111,
             slash: 191,
             'forward-slash': 191,
             // Tick, or `, or back-quote

--- a/test/test.js
+++ b/test/test.js
@@ -575,6 +575,13 @@ test('Test key binding without element, binding to `document`', function () {
     buildEvent(32, false, false, false, false);
 });
 
+test('Test forward-slash for Mac numpad keyboards', function () {
+    expect(1);
+
+    jwerty.key('/', this.assertjwerty);
+    buildEvent(111, false, false, false, false);
+});
+
 
 test('Test unbinding', function(){
     var firings = 0


### PR DESCRIPTION
I would suggest also to change the DSL of the multiple keys declaration, e.g. change '⌃+⇧+P/⌘+⇧+P' to '⌃+⇧+P|⌘+⇧+P'. Replace '/' with '|'.
This change will resolve the issue with standalone key declaration like '/', so the key press will be handled whether the '/' was pressed on the main num row OR '/' on the numpad extended keyboards. And by going this path you will be able to map '/' too.
Right now I'm not able to map single key declaration '/' to some action.
